### PR TITLE
Removed warnings on obj.h

### DIFF
--- a/obj.h
+++ b/obj.h
@@ -165,6 +165,24 @@ public:
         faces.push_back(face);
         unusedVerticesCount = 0;
     }
+    std::vector<Vertex>* getVertices() {
+      return &this->vertices;
+    }
+    Vertex* getVertex(int i) {
+      return &this->vertices[i];
+    }
+    std::vector<Face>* getFaces() {
+      return &this->faces;
+    }
+    Face* getFace(int i) {
+      return &this->faces[i];
+    }
+    int getFaceCount() {
+      return this->faces.size();
+    }
+    int getVertexCount() {
+      return this->vertices.size();
+    }
     void appendFace(const std::int32_t& v0, const std::int32_t& v1, const std::int32_t& v2, const std::int32_t& v3=-1){
         faces.push_back(Face(v0, v1, v2, v3));
         unusedVerticesCount = 0;

--- a/obj.h
+++ b/obj.h
@@ -29,8 +29,8 @@ public:
 
 
 class Face{
-    const std::int32_t numIndices;
-    const Vec4i indices;
+  const Vec4i indices;
+  const std::int32_t numIndices;
 
 public:
     Face(const std::int32_t& v0, const std::int32_t& v1, const std::int32_t& v2)
@@ -186,7 +186,7 @@ public:
             std::exit(EXIT_FAILURE);
         }
     }
-    
+
     void enableTextureCoordinates(const bool& arg = true){
         texCoordEnabled = arg;
     }
@@ -197,7 +197,7 @@ public:
 };
 
 
-class Line{ 
+class Line{
     std::int32_t numIndeces;
     std::vector<std::int32_t> indices;
 
@@ -221,9 +221,9 @@ public:
 
     // for debug
     void printIndices(){
-        for(int i=0; i<indices.size(); i++){
+        for(int i=0; i<(int)  indices.size(); i++){
             std::cout << indices[i] << " ";
-        } 
+        }
     }
 
     int getNumIndices() {return numIndeces;}
@@ -310,7 +310,7 @@ public:
             // int numIndices = lines[i].getNumIndices();
             auto indices = lines[i].getIndices();
             file << "l ";
-            for(int i=0; i<indices.size(); i++){
+            for(int i=0; i<(int)indices.size(); i++){
                 file << indices[i] + 1 << " ";
             }
             file << std::endl;

--- a/vector.h
+++ b/vector.h
@@ -105,7 +105,7 @@ public:
     Vec3(const float& x, const float& y, const float& z): x(x), y(y), z(z){};
 
     bool operator==(const Vec3& vec){
-    return (fabs(x - vec.x) <= FLT_EPSILON) 
+    return (fabs(x - vec.x) <= FLT_EPSILON)
             && (fabs(y - vec.y) <= FLT_EPSILON)
             && (fabs(z - vec.z) <= FLT_EPSILON);
     }
@@ -203,6 +203,26 @@ public:
         return *this;
     }
 
+    Vec3 cross(Vec3 b) {
+      return Vec3(y*b.z-z*b.y,
+                  z*b.x-x*b.z,
+                  x*b.y-y*b.x);
+    }
+
+    float dot(Vec3 b) {
+      return x*b.x+y*b.y+z*b.z;
+    }
+
+    float norm() {
+      return sqrt(pow(x,2)+pow(y,2)+pow(z,2));
+    }
+
+    float angleTo(Vec3 vec, Vec3 perp) {
+      float angle = acos(this->dot(vec)/(this->norm()*vec.norm()));
+      if (vec.dot(perp) < 0)
+        angle = 2*M_PI - angle;
+      return angle;
+    }
 
     friend std::ostream& operator<<(std::ostream& os, const Vec3& vec){
         os << vec.x << ", " << vec.y << ", " << vec.z;
@@ -218,9 +238,9 @@ public:
     Vec4(const float& n = 0): x(n), y(n), z(n), w(n){};
     Vec4(const float& x, const float& y, const float& z, const float& w): x(x), y(y), z(z), w(w){};
 
-        
+
     bool operator==(const Vec4& vec){
-        return (fabs(x - vec.x) <= FLT_EPSILON) 
+        return (fabs(x - vec.x) <= FLT_EPSILON)
                 && (fabs(y - vec.y) <= FLT_EPSILON)
                 && (fabs(z - vec.z) <= FLT_EPSILON)
                 && (fabs(w - vec.w) <= FLT_EPSILON);
@@ -345,7 +365,7 @@ public:
     Vec4i(const std::int32_t& n = 0): x(n), y(n), z(n), w(n){};
     Vec4i(const std::int32_t& x, const std::int32_t& y, const std::int32_t& z, const std::int32_t& w): x(x), y(y), z(z), w(w){};
 
-        
+
     bool operator==(const Vec4i& vec){
         return x == vec.x && y == vec.y && z == vec.z && w == vec.w;
     }


### PR DESCRIPTION
I'm using your lib for a simulation and some warnings appeared:

- The order of the declaration of the members in `Face` class was different than the initialization.

`src/wavefront/obj.h: In constructor ‘wow::Face::Face(const int32_t&, const int32_t&, const int32_t&)’:
src/wavefront/obj.h:33:17: warning: ‘wow::Face::indices’ will be initialized after [-Wreorder]
   33 |     const Vec4i indices;
      |                 ^~~~~~~
src/wavefront/obj.h:32:24: warning:   ‘const int32_t wow::Face::numIndices’ [-Wreorder]
   32 |     const std::int32_t numIndices;
      |                        ^~~~~~~~~~
src/wavefront/obj.h:36:5: warning:   when initialized here [-Wreorder]
   36 |     Face(const std::int32_t& v0, const std::int32_t& v1, const std::int32_t& v2)
      |     ^~~~
`
- `indices.size()` requires an explicit cast for `int`

`src/wavefront/obj.h: In member function ‘void wow::Line::printIndices()’:
src/wavefront/obj.h:224:23: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<int>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
  224 |         for(int i=0; i<indices.size(); i++){
      |                      ~^~~~~~~~~~~~~~~`